### PR TITLE
Fix to JS String.replace default behavior

### DIFF
--- a/src/url-formatter.ts
+++ b/src/url-formatter.ts
@@ -40,7 +40,7 @@ export const interceptorUrlFormatter = (config: AxiosRequestConfig): AxiosReques
   for (const paramName of Object.keys(config.params)) {
     const param = config.params[paramName]
     if (config.url && config.url.indexOf(`{${paramName}}`) > -1) {
-      config.url = config.url.replace(`{${paramName}}`, param)
+      config.url = config.url.replace(`{${paramName}}`, function () { return param })
       delete config.params[paramName]
     }
   }


### PR DESCRIPTION
Any param string that happens to include consecutive dollar-signs will lack one dollar sign and result in incorrect URIs